### PR TITLE
Fixed the user's name getting separated with semicolons

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -11,9 +11,9 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-ynh_app_setting_set_default --key=email --value=$(ynh_user_get_info --username=$admin --key=mail)
-ynh_app_setting_set_default --key=fullname --value=$(ynh_user_get_info --username=$admin --key=fullname)
-ynh_app_setting_set_default --key=username --value=$(ynh_user_get_info --username=$admin --key=username)
+ynh_app_setting_set_default --key=email --value="$(ynh_user_get_info --username=$admin --key=mail)"
+ynh_app_setting_set_default --key=fullname --value="$(ynh_user_get_info --username=$admin --key=fullname)"
+ynh_app_setting_set_default --key=username --value="$(ynh_user_get_info --username=$admin --key=username)"
 ynh_app_setting_set_default --key=php_upload_max_filesize --value=100M
 ynh_app_setting_set_default --key=php_post_max_size --value=100M
 ynh_app_setting_set_default --key=php_max_file_uploads --value=100M


### PR DESCRIPTION
## Problem

- If the user's full name has spaces they get replaced with semicolons

## Solution

- Added quotes around the variables so that they are treated as one value per variable

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
